### PR TITLE
fixed ParameterLoader and FullyConnected weights transpose

### DIFF
--- a/Sources/Adapters/Tensorflow/TFConverter+Mappers.swift
+++ b/Sources/Adapters/Tensorflow/TFConverter+Mappers.swift
@@ -119,7 +119,7 @@ public extension TFConverter {
                                   useBias: weightData.useBias,
                                   weights: weightData.weights,
                                   bias: weightData.bias,
-                                  transpose: HWIOtoOHWI,
+                                  transpose: HWIOtoOWHI,
                                   id: node.nodeDef.name)
         }
         mappers[Constants.Ops.Dense] = denseMapper

--- a/Sources/Core/SingleBinaryLoader.swift
+++ b/Sources/Core/SingleBinaryLoader.swift
@@ -35,7 +35,7 @@ public class SingleBinaryLoader: ParameterLoader {
     /// - Parameters:
     ///   - count: count of floats in file
     public func loadFile(count: Int) {
-        file = load(from: checkpoint, size: count * MemoryLayout<Float>.stride, ofType: "")
+        file = load(from: checkpoint, size: count, ofType: "")
     }
 
     public func loadWeights(for id: String, modifier: String, size: Int) -> UnsafePointer<Float> {
@@ -43,7 +43,7 @@ public class SingleBinaryLoader: ParameterLoader {
             return file! + offset
         } else {
             let ret = file! + currentOffset
-            currentOffset += size * MemoryLayout<Float>.stride
+            currentOffset += size
             return ret
         }
     }

--- a/Sources/Helpers/Helpers.swift
+++ b/Sources/Helpers/Helpers.swift
@@ -38,3 +38,21 @@ func HWIOtoOHWI(weights: Data, shape: Shape) -> Data {
 
     return Data.init(bytes: transposed, count: shape.totalCount * MemoryLayout<Float>.stride)
 }
+
+func HWIOtoOWHI(weights: Data, shape: Shape) -> Data {
+    var transposed = [Float](repeating: 0.0, count: shape.totalCount)
+
+    for o in 0..<shape.outputChannels {
+        for h in 0..<shape.height {
+            for w in 0..<shape.width {
+                for i in 0..<shape.inputChannels {
+                    let tIndex = i + shape.inputChannels * (h + shape.height * (w + shape.width * (o)))
+                    let wIndex = o + shape.outputChannels * (i + shape.inputChannels * (w + shape.width * (h)))
+                    transposed[tIndex] = weights.pointer()![wIndex]
+                }
+            }
+        }
+    }
+
+    return Data.init(bytes: transposed, count: shape.totalCount * MemoryLayout<Float>.stride)
+}


### PR DESCRIPTION
MPSCNNFullyConnected takes the weights in a different order than MPSCNNConvolution
(https://developer.apple.com/reference/metalperformanceshaders under CNN Tips)