### PR TITLE
fixed ordering issue while optimizing the tensor flow graph

### DIFF
--- a/Sources/Adapters/TFOptimizer.swift
+++ b/Sources/Adapters/TFOptimizer.swift
@@ -29,7 +29,7 @@ public extension TFOptimizer {
             node.nodeDef.attr[Constants.CustomAttr.neuron] = neuron
 
             for output in next.outgoingNodes() {
-                output.addIncomingEdge(from: node)
+                output.replace(incomingEdge: next, with: node)
             }
 
             next.strip()

--- a/Sources/Adapters/Tensorflow/TFConvOptimizer.swift
+++ b/Sources/Adapters/Tensorflow/TFConvOptimizer.swift
@@ -29,7 +29,7 @@ class TFConvOptimizer: TFOptimizer {
                     let biasVar = (biasAdd.incomingNodes() as? [TFNode])?.first(where: { $0.nodeDef.isTFVariableOrConstOp }) {
                     node.addIncomingEdge(from: biasVar)
                     for output in biasAdd.outgoingNodes() {
-                        output.addIncomingEdge(from: node)
+                        output.replace(incomingEdge: biasAdd, with: node)
                     }
                     biasAdd.strip()
                 }

--- a/Sources/Graph/Node.swift
+++ b/Sources/Graph/Node.swift
@@ -51,6 +51,18 @@ public extension Node {
         }
     }
 
+    /// Replaces the `old` incoming node by `new`. Also replaces the outgoing
+    /// ocurrence of `old` in the `new` node.
+    func replace(incomingEdge old: Node, with new: Node) {
+        let incoming = incomingNodes()
+        if let index = incoming.index(where: { $0.isEqual(to: old) }) {
+            edgeIn[index] = captureWeakly(object: new)
+            if let outIndex = new.edgeOut.index(where: { $0.isEqual(to: old)}) {
+                new.edgeOut[outIndex] = self
+            }
+        }
+    }
+
     /// All incoming connections
     func incomingNodes() -> [Node] {
         return edgeIn.flatMap { $0() }


### PR DESCRIPTION
## Description
When converting convolutions from tensor flow graph, some graph operations were changing the order of incoming nodes.

## Changes proposed in this request:
* Added a function to explicitly replace an incoming node (at the already existent index) for a new node and keep everything connected.

