### PR TITLE
Added support for iPhone 6 in Concat layer

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "apple/swift-protobuf" "e3a71a89a856d894ea44cec1d0307d22c37df0df"
+github "apple/swift-protobuf" "66f11ac70dad7190e661429e56d9bb76c1430386"

--- a/Sources/Layers/Concat.swift
+++ b/Sources/Layers/Concat.swift
@@ -56,10 +56,9 @@ open class Concat: NetworkLayer {
         let tpTG = MTLSizeMake(32, 8, 1)
         commandEncoder.setComputePipelineState(pipeline)
 
-        var inputTextures: [MTLTexture?] = [MTLTexture?].init(repeating: nil, count: maxInputTextures)
-        incoming.enumerated().forEach { inputTextures[$0.offset] = $0.element.outputImage.texture }
-        let texturesPointer: UnsafeMutablePointer<MTLTexture?> = UnsafeMutablePointer(mutating: inputTextures)
-        commandEncoder.setTextures(texturesPointer, with: NSRange.init(location: 0, length: maxInputTextures))
+        (0..<min(maxInputTextures, incoming.count)).forEach {
+            commandEncoder.setTexture(incoming[$0].outputImage.texture, at: $0)
+        }
 
         commandEncoder.setTexture(outputImage.texture, at: maxInputTextures)
         let threadgroupsPerGrid = outputImage.texture.threadGrid(threadGroup: tpTG)

--- a/Sources/Metal/concat.metal
+++ b/Sources/Metal/concat.metal
@@ -9,7 +9,27 @@
 #include <metal_stdlib>
 using namespace metal;
 
-#define INPUT_TEXTURES_COUNT 10
+/********************** Concat MARCO **********************/
+
+#define INPUT_TEXTURES_COUNT (10)
+
+#define INPUT_TEXTURE(i) src ## _ ## i
+
+#define COMPUTE_INPUT_TEXTURE(inputAxis, outputAxis, sizeFunction, i)\
+    {\
+        if (is_null_texture(INPUT_TEXTURE(i)))\
+            return;\
+        \
+        ushort size = INPUT_TEXTURE(i).sizeFunction;\
+        if (outputAxis < offset + size) {\
+            inputAxis = outputAxis - offset;\
+            auto input = half4(INPUT_TEXTURE(i).read(ushort2(inputX, inputY), inputZ));\
+            dest.write(float4(input), ushort2(outputX, outputY), outputZ);\
+            return;\
+        }\
+        \
+        offset += size;\
+    }
 
 #define CONCAT(inputAxis, outputAxis, sizeFunction)\
     ushort offset = 0;\
@@ -21,81 +41,94 @@ using namespace metal;
     auto inputY = gid.y;\
     auto inputZ = gid.z;\
 \
-    auto inputTextureIndex = 0;\
-\
-    for(auto i = 0; i < INPUT_TEXTURES_COUNT; i++) {\
-        if (is_null_texture(src[i]))\
-            break;\
-\
-        ushort size = sizeFunction;\
-        if (outputAxis < offset + size) {\
-            inputTextureIndex = i;\
-            inputAxis = outputAxis - offset;\
-            break;\
-        }\
-\
-        offset += size;\
-    }\
-\
-    auto input = half4(src[inputTextureIndex].read(ushort2(inputX, inputY), inputZ));\
-    dest.write(float4(input), ushort2(outputX, outputY), outputZ);\
+    COMPUTE_INPUT_TEXTURE(inputAxis, outputAxis, sizeFunction, 0);\
+    COMPUTE_INPUT_TEXTURE(inputAxis, outputAxis, sizeFunction, 1);\
+    COMPUTE_INPUT_TEXTURE(inputAxis, outputAxis, sizeFunction, 2);\
+    COMPUTE_INPUT_TEXTURE(inputAxis, outputAxis, sizeFunction, 3);\
+    COMPUTE_INPUT_TEXTURE(inputAxis, outputAxis, sizeFunction, 4);\
+    COMPUTE_INPUT_TEXTURE(inputAxis, outputAxis, sizeFunction, 5);\
+    COMPUTE_INPUT_TEXTURE(inputAxis, outputAxis, sizeFunction, 6);\
+    COMPUTE_INPUT_TEXTURE(inputAxis, outputAxis, sizeFunction, 7);\
+    COMPUTE_INPUT_TEXTURE(inputAxis, outputAxis, sizeFunction, 8);\
+    COMPUTE_INPUT_TEXTURE(inputAxis, outputAxis, sizeFunction, 9);\
+
+/********** Helpers to define a list of input textures *******/
+
+#define TEXTURE(type, name, i) type name ## _ ## i [[ texture(i) ]]
+
+#define TEXTURES_ARRAY(type, name)\
+    TEXTURE(type, name, 0),\
+    TEXTURE(type, name, 1),\
+    TEXTURE(type, name, 2),\
+    TEXTURE(type, name, 3),\
+    TEXTURE(type, name, 4),\
+    TEXTURE(type, name, 5),\
+    TEXTURE(type, name, 6),\
+    TEXTURE(type, name, 7),\
+    TEXTURE(type, name, 8),\
+    TEXTURE(type, name, 9)\
+
+/*** typedefs in order to avois issues with ',' in macros ***/
+
+typedef const texture2d_array<float, access::read> texture2d_float_array;
+typedef const texture2d<float, access::read> texture2d_float;
 
 /********************** Concat along x **********************/
 
 kernel void concat_x(
-                const array<texture2d_array<float, access::read>, INPUT_TEXTURES_COUNT> src [[ texture(0) ]],
+                TEXTURES_ARRAY(texture2d_float_array, src),
                 texture2d_array<float, access::write> dest [[ texture(INPUT_TEXTURES_COUNT) ]],
                 ushort3 gid [[thread_position_in_grid]]) {
 
-    CONCAT(inputX, outputX, src[i].get_width());
+    CONCAT(inputX, outputX, get_width());
 
 }
 
 kernel void concat_x_3(
-                     const array<texture2d<float, access::read>, INPUT_TEXTURES_COUNT> src [[ texture(0) ]],
+                     TEXTURES_ARRAY(texture2d_float, src),
                      texture2d<float, access::write> dest [[ texture(INPUT_TEXTURES_COUNT) ]],
                      ushort3 gid [[thread_position_in_grid]]) {
 
-    CONCAT(inputX, outputX, src[i].get_width());
+    CONCAT(inputX, outputX, get_width());
 
 }
 
 /********************** Concat along y **********************/
 
 kernel void concat_y(
-                   const array<texture2d_array<float, access::read>, INPUT_TEXTURES_COUNT> src [[ texture(0) ]],
+                   TEXTURES_ARRAY(texture2d_float_array, src),
                    texture2d_array<float, access::write> dest [[ texture(INPUT_TEXTURES_COUNT) ]],
                    ushort3 gid [[thread_position_in_grid]]) {
 
-    CONCAT(inputY, outputY, src[i].get_height());
+    CONCAT(inputY, outputY, get_height());
 
 }
 
 kernel void concat_y_3(
-                    const array<texture2d<float, access::read>, INPUT_TEXTURES_COUNT> src [[ texture(0) ]],
+                    TEXTURES_ARRAY(texture2d_float, src),
                     texture2d<float, access::write> dest [[ texture(INPUT_TEXTURES_COUNT) ]],
                     ushort3 gid [[thread_position_in_grid]]) {
 
-    CONCAT(inputY, outputY, src[i].get_height());
+    CONCAT(inputY, outputY, get_height());
 
 }
 
 /********************** Concat along z **********************/
 
 kernel void concat_z( /* only works when each input texture has a depth multiple of 4. */
-                     const array<texture2d_array<float, access::read>, INPUT_TEXTURES_COUNT> src [[ texture(0) ]],
+                     TEXTURES_ARRAY(texture2d_float_array, src),
                      texture2d_array<float, access::write> dest [[ texture(INPUT_TEXTURES_COUNT) ]],
                      ushort3 gid [[thread_position_in_grid]]) {
 
-    CONCAT(inputZ, outputZ, src[i].get_array_size());
+    CONCAT(inputZ, outputZ, get_array_size());
 
 }
 
 kernel void concat_z_3(
-                    const array<texture2d<float, access::read>, INPUT_TEXTURES_COUNT> src [[ texture(0) ]],
+                    TEXTURES_ARRAY(texture2d_float, src),
                     texture2d_array<float, access::write> dest [[ texture(INPUT_TEXTURES_COUNT) ]],
                     ushort3 gid [[thread_position_in_grid]]) {
 
-    CONCAT(inputZ, outputZ, 1);
+    CONCAT(inputZ, outputZ, get_width() & 0x00 | 0x01); /* Just want to pass 1 as the sizeFunction */
 
 }

--- a/Sources/Metal/concat.metal
+++ b/Sources/Metal/concat.metal
@@ -13,6 +13,8 @@ using namespace metal;
 
 /* Changing this value implies changing the
  'SRC_TEXTURES_ARRAY' & 'CONCAT' macros as well.
+ Additionally it must match the property 'maxInputTextures'
+ of the Concat class defined in the Concat.swift file.
  */
 #define INPUT_TEXTURES_COUNT (10)
 

--- a/Sources/Metal/concat.metal
+++ b/Sources/Metal/concat.metal
@@ -9,11 +9,14 @@
 #include <metal_stdlib>
 using namespace metal;
 
-/********************** Concat MARCO **********************/
+/********************** Concat MACRO **********************/
 
+/* Changing this value implies changing the
+ 'SRC_TEXTURES_ARRAY' & 'CONCAT' macros as well.
+ */
 #define INPUT_TEXTURES_COUNT (10)
 
-#define INPUT_TEXTURE(i) src ## _ ## i
+#define INPUT_TEXTURE(i) src_ ## i
 
 #define COMPUTE_INPUT_TEXTURE(inputAxis, outputAxis, sizeFunction, i)\
     {\
@@ -54,21 +57,21 @@ using namespace metal;
 
 /********** Helpers to define a list of input textures *******/
 
-#define TEXTURE(type, name, i) type name ## _ ## i [[ texture(i) ]]
+#define TEXTURE(type, i) type INPUT_TEXTURE(i) [[ texture(i) ]]
 
-#define TEXTURES_ARRAY(type, name)\
-    TEXTURE(type, name, 0),\
-    TEXTURE(type, name, 1),\
-    TEXTURE(type, name, 2),\
-    TEXTURE(type, name, 3),\
-    TEXTURE(type, name, 4),\
-    TEXTURE(type, name, 5),\
-    TEXTURE(type, name, 6),\
-    TEXTURE(type, name, 7),\
-    TEXTURE(type, name, 8),\
-    TEXTURE(type, name, 9)\
+#define SRC_TEXTURES_ARRAY(type)\
+    TEXTURE(type, 0),\
+    TEXTURE(type, 1),\
+    TEXTURE(type, 2),\
+    TEXTURE(type, 3),\
+    TEXTURE(type, 4),\
+    TEXTURE(type, 5),\
+    TEXTURE(type, 6),\
+    TEXTURE(type, 7),\
+    TEXTURE(type, 8),\
+    TEXTURE(type, 9)\
 
-/*** typedefs in order to avois issues with ',' in macros ***/
+/*** typedefs in order to avoid issues with ',' in macros ***/
 
 typedef const texture2d_array<float, access::read> texture2d_float_array;
 typedef const texture2d<float, access::read> texture2d_float;
@@ -76,7 +79,7 @@ typedef const texture2d<float, access::read> texture2d_float;
 /********************** Concat along x **********************/
 
 kernel void concat_x(
-                TEXTURES_ARRAY(texture2d_float_array, src),
+                SRC_TEXTURES_ARRAY(texture2d_float_array),
                 texture2d_array<float, access::write> dest [[ texture(INPUT_TEXTURES_COUNT) ]],
                 ushort3 gid [[thread_position_in_grid]]) {
 
@@ -85,7 +88,7 @@ kernel void concat_x(
 }
 
 kernel void concat_x_3(
-                     TEXTURES_ARRAY(texture2d_float, src),
+                     SRC_TEXTURES_ARRAY(texture2d_float),
                      texture2d<float, access::write> dest [[ texture(INPUT_TEXTURES_COUNT) ]],
                      ushort3 gid [[thread_position_in_grid]]) {
 
@@ -96,7 +99,7 @@ kernel void concat_x_3(
 /********************** Concat along y **********************/
 
 kernel void concat_y(
-                   TEXTURES_ARRAY(texture2d_float_array, src),
+                   SRC_TEXTURES_ARRAY(texture2d_float_array),
                    texture2d_array<float, access::write> dest [[ texture(INPUT_TEXTURES_COUNT) ]],
                    ushort3 gid [[thread_position_in_grid]]) {
 
@@ -105,7 +108,7 @@ kernel void concat_y(
 }
 
 kernel void concat_y_3(
-                    TEXTURES_ARRAY(texture2d_float, src),
+                    SRC_TEXTURES_ARRAY(texture2d_float),
                     texture2d<float, access::write> dest [[ texture(INPUT_TEXTURES_COUNT) ]],
                     ushort3 gid [[thread_position_in_grid]]) {
 
@@ -116,7 +119,7 @@ kernel void concat_y_3(
 /********************** Concat along z **********************/
 
 kernel void concat_z( /* only works when each input texture has a depth multiple of 4. */
-                     TEXTURES_ARRAY(texture2d_float_array, src),
+                     SRC_TEXTURES_ARRAY(texture2d_float_array),
                      texture2d_array<float, access::write> dest [[ texture(INPUT_TEXTURES_COUNT) ]],
                      ushort3 gid [[thread_position_in_grid]]) {
 
@@ -125,10 +128,10 @@ kernel void concat_z( /* only works when each input texture has a depth multiple
 }
 
 kernel void concat_z_3(
-                    TEXTURES_ARRAY(texture2d_float, src),
+                    SRC_TEXTURES_ARRAY(texture2d_float),
                     texture2d_array<float, access::write> dest [[ texture(INPUT_TEXTURES_COUNT) ]],
                     ushort3 gid [[thread_position_in_grid]]) {
 
-    CONCAT(inputZ, outputZ, get_width() & 0x00 | 0x01); /* Just want to pass 1 as the sizeFunction */
+    CONCAT(inputZ, outputZ, get_width() * 0 + 1); /* Just want to pass 1 as the sizeFunction */
 
 }


### PR DESCRIPTION
Fixes #38 
## Description
As @bryant1410 said:
"According to the [Metal Feature Set Table](https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf), an array of textures is unavailable in iOS 10 for GPU families prior to 3. iphone 6 uses A8 which has a version 2 of the GPU family, in contrast with the A9 and A10 of iphone 6s and 7 which have version 3. So the problem is the lack of support for array of textures in iphone 6 devices."

## Changes proposed in this request:
* Modified concat shader functions to NOT use arrays.

