### PR TITLE
Ignore TF control inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ To know more about this have a look at [API](Documentation/API.md).
 ## Requirements
 
 * iOS 10.0+
-* Xcode 8.3+
+* Xcode 8.3+ or Xcode 9.0 beta 3+
 
 ## Getting involved
 

--- a/Sources/Adapters/Tensorflow/TFGraph.swift
+++ b/Sources/Adapters/Tensorflow/TFGraph.swift
@@ -32,7 +32,10 @@ public class TFGraph: GraphProtocol {
         }
 
         for node in nodes {
-            for input in node.nodeDef.input {
+            // Filter TF control inputs
+            let filtered = node.nodeDef.input.filter { $0.first != "^" }
+            
+            for input in filtered {
                 if let inputNode = nodesByName[input] {
                     node.addIncomingEdge(from: inputNode)
                 } else {


### PR DESCRIPTION
Ignore a TF node control inputs, the ones which name starts with a `^`, instead of printing an `Unknown Input` warning.

