### PR TITLE
Fixed threadGroups size calculation

### DIFF
--- a/Sources/Layers/BGRAtoRGBA.swift
+++ b/Sources/Layers/BGRAtoRGBA.swift
@@ -35,8 +35,7 @@ open class BGRAtoRGBA: NetworkLayer {
         encoder.setTexture(getIncoming()[0].outputImage.texture, at: 0)
         encoder.setTexture(outputImage.texture, at: 1)
         let threadsPerGroups = MTLSizeMake(32, 8, 1)
-        let threadGroups = MTLSizeMake((outputImage.texture.width + threadsPerGroups.width - 1) / threadsPerGroups.width,
-                                       (outputImage.texture.height + threadsPerGroups.height - 1) / threadsPerGroups.height, 1)
+        let threadGroups = outputImage.texture.threadGrid(threadGroup: threadsPerGroups)
         encoder.dispatchThreadgroups(threadGroups, threadsPerThreadgroup: threadsPerGroups)
         encoder.endEncoding()
     }

--- a/Sources/Layers/ImageLinearTransform.swift
+++ b/Sources/Layers/ImageLinearTransform.swift
@@ -45,8 +45,7 @@ open class ImageLinearTransform: NetworkLayer {
         encoder.setTexture(getIncoming()[0].outputImage.texture, at: 0)
         encoder.setTexture(outputImage.texture, at: 1)
         let threadsPerGroups = MTLSizeMake(32, 8, 1)
-        let threadGroups = MTLSizeMake(outputImage.texture.width / threadsPerGroups.width,
-                                       outputImage.texture.height / threadsPerGroups.height, 1)
+        let threadGroups = outputImage.texture.threadGrid(threadGroup: threadsPerGroups)
         encoder.dispatchThreadgroups(threadGroups, threadsPerThreadgroup: threadsPerGroups)
         encoder.endEncoding()
     }


### PR DESCRIPTION
## Description
The grid size calculation was wrong for some image instances in the layers `BGRAtoRGBA` & `ImageLinearTransform` layers.


