### PR TITLE
Temporary images

### DIFF
--- a/Example/BatchNormTest.swift
+++ b/Example/BatchNormTest.swift
@@ -96,7 +96,7 @@ class BatchNormTest: BenderTest {
         styleNet.initialize()
         let metalTexture = inputTexture.metalTexture(with: Device.shared)
         styleNet.run(input: MPSImage(texture: metalTexture, featureChannels: inputTexture.depth)) { image in
-            let textureFromGpu = Texture(metalTexture: image.texture, size: expectedOutput.size)
+            let textureFromGpu = Texture(metalTexture: image!.texture, size: expectedOutput.size)
             assert(textureFromGpu.isEqual(to: expectedOutput, threshold: 0.01))
             completion()
         }

--- a/Example/Example/GrayScale.swift
+++ b/Example/Example/GrayScale.swift
@@ -29,18 +29,18 @@ class GrayScale: NetworkLayer {
         let incoming = getIncoming()[0]
         assert(incoming.outputSize.f <= 4, "GrayScale input must have at most 4 feature channels")
         outputSize = LayerSize(h: incoming.outputSize.h, w: incoming.outputSize.w, f: outputChannels)
-        outputImage = MPSImage(device: device, imageDescriptor: MPSImageDescriptor(layerSize: outputSize))
+        createOutputs(size: outputSize)
     }
 
-    override func execute(commandBuffer: MTLCommandBuffer) {
+    override func execute(commandBuffer: MTLCommandBuffer, executionIndex: Int = 0) {
         let incoming = getIncoming()
         let encoder = commandBuffer.makeComputeCommandEncoder()!
         encoder.label = "GrayScale encoder"
         encoder.setComputePipelineState(pipeline)
-        encoder.setTexture(incoming[0].outputImage.texture, index: 0)
-        encoder.setTexture(outputImage.texture, index: 1)
+        encoder.setTexture(incoming[0].outputs[executionIndex].texture, index: 0)
+        encoder.setTexture(outputs[executionIndex].texture, index: 1)
         let threadsPerGroups = MTLSizeMake(32, 4, 1)
-        let threadGroups = outputImage.texture.threadGrid(threadGroup: threadsPerGroups)
+        let threadGroups = outputs[executionIndex].texture.threadGrid(threadGroup: threadsPerGroups)
         encoder.dispatchThreadgroups(threadGroups, threadsPerThreadgroup: threadsPerGroups)
         encoder.endEncoding()
     }

--- a/Example/Example/InceptionExample.swift
+++ b/Example/Example/InceptionExample.swift
@@ -88,7 +88,7 @@ class InceptionViewController: UIViewController, UINavigationControllerDelegate 
                 return
             }
             model.run(input: image, queue: commandQueue) { [weak self] result in
-                let arr = result.toArray()
+                let arr = result!.toArray()
                 let top5 = arr.argsort(by: > ).prefix(5)
                 self?.label.text = top5.reduce("") {
                     return $0 + labels[$1] + "\n"

--- a/Example/Example/StyleTransferViewController.swift
+++ b/Example/Example/StyleTransferViewController.swift
@@ -56,7 +56,7 @@ class StyleTransferViewController: UIViewController, ExampleViewController {
         buffer.commit()
         buffer.waitUntilCompleted()
         styleNet.run(input: image, queue: commandQueue) { [weak self] imageA in
-            if let buffer = self?.getPixelBuffer(from: imageA.texture, bufferPool: self!.pixelBufferPool!) {
+            if let buffer = self?.getPixelBuffer(from: imageA!.texture, bufferPool: self!.pixelBufferPool!) {
                 let ciImage = CIImage(cvImageBuffer: buffer)
                 let context = CIContext()
                 let cgImage = context.createCGImage(ciImage, from: ciImage.extent)

--- a/Example/Example/Tests/ConcatTest.swift
+++ b/Example/Example/Tests/ConcatTest.swift
@@ -177,7 +177,7 @@ class ConcatTest: BenderTest {
         styleNet.initialize()
         let metalTexture = inputTextures[0].metalTexture(with: Device.shared)
         styleNet.run(input: MPSImage(texture: metalTexture, featureChannels: inputTextures[0].depth)) { image in
-            let textureFromGpu = Texture(metalTexture: image.texture, size: expectedOutput.size)
+            let textureFromGpu = Texture(metalTexture: image!.texture, size: expectedOutput.size)
             assert(textureFromGpu.isEqual(to: expectedOutput))
             completion()
         }

--- a/Example/Example/Tests/DenseTests.swift
+++ b/Example/Example/Tests/DenseTests.swift
@@ -39,7 +39,7 @@ class DenseTest: BenderTest {
 
         network = Network.load(url: url, inputSizes: sizes, converter: converter)
         network.run(inputs: [inputImage]) { result in
-            let out = Texture(metalTexture: result.texture, size: LayerSize(h: 1, w: 1, f: 10))
+            let out = Texture(metalTexture: result!.texture, size: LayerSize(h: 1, w: 1, f: 10))
             assert(out.isEqual(to: DenseDataSet.result, threshold: 0.01))
             completion()
         }

--- a/Example/Example/Tests/Helpers/ConstantLayer.swift
+++ b/Example/Example/Tests/Helpers/ConstantLayer.swift
@@ -27,8 +27,8 @@ open class Constant: NetworkLayer {
         constantOutputImage = MPSImage(texture: constantOutputTexture.metalTexture(with: device), featureChannels: constantOutputTexture.size.f)
     }
 
-    open override func execute(commandBuffer: MTLCommandBuffer) {
-        outputImage = constantOutputImage
+    open override func execute(commandBuffer: MTLCommandBuffer, executionIndex: Int = 0) {
+        outputs.append(constantOutputImage)
     }
 
 }

--- a/Example/Example/Tests/Helpers/ConstantLayer.swift
+++ b/Example/Example/Tests/Helpers/ConstantLayer.swift
@@ -19,8 +19,8 @@ open class Constant: NetworkLayer {
         constantOutputTexture = outputTexture
     }
 
-    open override func initialize(network: Network, device: MTLDevice) {
-        super.initialize(network: network, device: device)
+    open override func initialize(network: Network, device: MTLDevice, temporaryImage: Bool = true) {
+        super.initialize(network: network, device: device, temporaryImage: temporaryImage)
         let incoming: [NetworkLayer] = getIncoming()
         assert(incoming.count == 1, "Constant must have one input, not \(incoming.count)")
         outputSize = constantOutputTexture.size
@@ -28,7 +28,7 @@ open class Constant: NetworkLayer {
     }
 
     open override func execute(commandBuffer: MTLCommandBuffer, executionIndex: Int = 0) {
-        outputs.append(constantOutputImage)
+        rewireIdentity(at: executionIndex, image: constantOutputImage)
     }
 
 }

--- a/Example/Example/Tests/InstanceNormTests.swift
+++ b/Example/Example/Tests/InstanceNormTests.swift
@@ -35,7 +35,7 @@ class InstanceNormTest: BenderTest {
         let metalTexture = texture.metalTexture(with: Device.shared)
         let cpuComputed = cpuInstanceNorm(input: texture, weights: weights, bias: bias)
         styleNet.run(input: MPSImage(texture: metalTexture, featureChannels: texture.depth)) { image in
-            let textureFromGpu = Texture(metalTexture: image.texture, size: texture.size)
+            let textureFromGpu = Texture(metalTexture: image!.texture, size: texture.size)
             assert(textureFromGpu.isEqual(to: cpuComputed, threshold: 0.002))
             completion()
         }

--- a/Example/Example/Tests/LocalResponseNormTest.swift
+++ b/Example/Example/Tests/LocalResponseNormTest.swift
@@ -39,7 +39,7 @@ class LocalResponseNormTest: BenderTest {
         let metalTexture = texture.metalTexture(with: Device.shared)
         let cpuComputed = cpuLocalResponseNorm(input: texture, parameters: parameters)
         styleNet.run(input: MPSImage(texture: metalTexture, featureChannels: texture.depth)) { image in
-            let textureFromGpu = Texture(metalTexture: image.texture, size: texture.size)
+            let textureFromGpu = Texture(metalTexture: image!.texture, size: texture.size)
             assert(textureFromGpu.isEqual(to: cpuComputed, threshold: 0.001))
             completion()
         }

--- a/Example/MNISTTestController.swift
+++ b/Example/MNISTTestController.swift
@@ -176,12 +176,12 @@ class MNISTTestController: UIViewController, ExampleViewController {
     func runNetwork(_ image: MPSImage) {
         networkRunQueue.async { [weak self] in
             self?.network.run(input: image, queue: self!.commandQueue) { [weak self] results in
-                let numbers = Texture(metalTexture: results.texture, size: LayerSize(h: 1, w: 1, f: 10))
+                let numbers = Texture(metalTexture: results!.texture, size: LayerSize(h: 1, w: 1, f: 10))
                 self?.didScan(numbers: numbers.data.flatMap { $0 })
             }
 
             self?.scaledNetwork.run(input: image, queue: self!.commandQueue) { [weak self] (outputImage) in
-                self?._texture = outputImage.texture
+                self?._texture = outputImage!.texture
             }
         }
     }

--- a/Sources/Core/Network.swift
+++ b/Sources/Core/Network.swift
@@ -26,6 +26,10 @@ public class Network {
     /// Responsible for loading the parameters
     public var parameterLoader: ParameterLoader
 
+    /// If you encode several command buffers before the previous one finishes execution then we might need to duplicate internal resources
+    /// to avoid different executions to write on each others results.
+    public var maxConcurrentExecutions = 1
+
     /// If set to true will print information about the graph and generated dependency list
     public var verbose = false
 
@@ -34,6 +38,7 @@ public class Network {
     }
 
     var initialized = false
+
 
     /// - Parameters:
     ///   - inputSizes: An array of tuples where the first item is the identifier of an input node and the second is its size.
@@ -166,18 +171,21 @@ public class Network {
         input: MPSImage,
         queue: MTLCommandQueue? = nil,
         dispatchQueue: DispatchQueue? = nil,
-        callback: @escaping (MPSImage) -> Void) {
+        executionIndex: Int = 0,
+        callback: @escaping (MPSImage?) -> Void) {
 
-        run(inputs: [input], queue: queue, dispatchQueue: dispatchQueue, callback: callback)
+        run(inputs: [input], queue: queue, dispatchQueue: dispatchQueue, executionIndex: executionIndex, callback: callback)
     }
 
     public func run(
         inputs: [MPSImage],
         queue: MTLCommandQueue? = nil,
         dispatchQueue: DispatchQueue? = nil,
-        callback: @escaping (MPSImage) -> Void) {
+        executionIndex: Int = 0,
+        callback: @escaping (MPSImage?) -> Void) {
 
         guard initialized else {
+            callback(nil)
             return
         }
         
@@ -196,7 +204,7 @@ public class Network {
         }
         autoreleasepool {
             for layer in nodes {
-                layer.execute(commandBuffer: commandBuffer)
+                layer.execute(commandBuffer: commandBuffer, executionIndex: executionIndex)
             }
             commandBuffer.commit()
 
@@ -205,11 +213,11 @@ public class Network {
                     guard let me = self else { return }
 
                     commandBuffer.waitUntilCompleted()
-                    callback(me.nodes.last!.outputImage)
+                    callback(me.nodes.last!.outputs[executionIndex])
                 }
             } else {
                 commandBuffer.waitUntilCompleted()
-                callback(nodes.last!.outputImage)
+                callback(nodes.last!.outputs[executionIndex])
             }
         }
     }

--- a/Sources/Core/Network.swift
+++ b/Sources/Core/Network.swift
@@ -23,6 +23,10 @@ public class Network {
     /// All the layers of the network
     var nodes = [NetworkLayer]()
 
+    /// Nodes for which the result will be a MPSImage instead of MPSTemporaryImage.
+    /// You can use `node(for id: String)` to get hold of the nodes.
+    public var permanentOutputNodes = [NetworkLayer]()
+
     /// Responsible for loading the parameters
     public var parameterLoader: ParameterLoader
 
@@ -37,7 +41,11 @@ public class Network {
         return nodes.first(where: { $0.id == id })
     }
 
-    var initialized = false
+    private var initialized = false
+
+    private var runningCount = 0
+
+    private var descriptors: [MPSImageDescriptor]!
 
 
     /// - Parameters:
@@ -146,14 +154,24 @@ public class Network {
             nodes = DependencyListBuilder().list(from: startNodes as [NetworkLayer])
         }
 
-        for layer in nodes {
-            layer.initialize(network: self, device: Device.shared)
+        if let outputNode = nodes.last, !permanentOutputNodes.contains(outputNode) {
+            permanentOutputNodes.append(outputNode)
         }
+
+        // Remove dummy nodes
+        nodes.forEach { ($0 as? Dummy)?.removeFromGraph() }
         nodes = nodes.filter { !($0 is Dummy) }
+
+        // initialize layers
+        for layer in nodes {
+            layer.initialize(network: self, device: Device.shared, temporaryImage: !permanentOutputNodes.contains(layer))
+        }
+
+        descriptors = nodes.flatMap { $0.descriptor }
 
         if verbose {
             _ = nodes.map {
-                debugPrint($0.id)
+                debugPrint($0, " => ", $0.id)
             }
         }
 
@@ -167,22 +185,20 @@ public class Network {
     ///   - queue: the command queue on which to run the kernels
     ///   - dispatchQueue: the dispatch queue where to run
     ///   - callback: will be called with the output image
-    public func run(
-        input: MPSImage,
-        queue: MTLCommandQueue? = nil,
-        dispatchQueue: DispatchQueue? = nil,
-        executionIndex: Int = 0,
-        callback: @escaping (MPSImage?) -> Void) {
+    public func run(input: MPSImage,
+                    queue: MTLCommandQueue? = nil,
+                    dispatchQueue: DispatchQueue? = nil,
+                    executionIndex: Int = 0,
+                    callback: @escaping (MPSImage?) -> Void) {
 
         run(inputs: [input], queue: queue, dispatchQueue: dispatchQueue, executionIndex: executionIndex, callback: callback)
     }
 
-    public func run(
-        inputs: [MPSImage],
-        queue: MTLCommandQueue? = nil,
-        dispatchQueue: DispatchQueue? = nil,
-        executionIndex: Int = 0,
-        callback: @escaping (MPSImage?) -> Void) {
+    public func run(inputs: [MPSImage],
+                    queue: MTLCommandQueue? = nil,
+                    dispatchQueue: DispatchQueue? = nil,
+                    executionIndex: Int = 0,
+                    callback: @escaping (MPSImage?) -> Void) {
 
         guard initialized else {
             callback(nil)
@@ -193,6 +209,10 @@ public class Network {
             fatalError("You must pass as many inputs (" + String(inputs.count) + ") as inputSize's" + String(startNodes.count) +
                 " you passed when creating the network")
         }
+
+        // Increment running count
+        runningCount += 1
+
         let commandQueue = queue ?? Device.shared.makeCommandQueue()!
 
         commandQueue.insertDebugCaptureBoundary() // DEBUG
@@ -202,6 +222,10 @@ public class Network {
         for (index, input) in inputs.enumerated() {
             startNodes[index].inputImage = input
         }
+
+        // prefetch storage for run
+        MPSTemporaryImage.prefetchStorage(with: commandBuffer, imageDescriptorList: descriptors)
+
         autoreleasepool {
             for layer in nodes {
                 layer.execute(commandBuffer: commandBuffer, executionIndex: executionIndex)
@@ -213,11 +237,13 @@ public class Network {
                     guard let me = self else { return }
 
                     commandBuffer.waitUntilCompleted()
-                    callback(me.nodes.last!.outputs[executionIndex])
+                    callback(me.nodes.last!.getOutput(index: executionIndex))
+                    me.runningCount -= 1
                 }
             } else {
                 commandBuffer.waitUntilCompleted()
-                callback(nodes.last!.outputs[executionIndex])
+                callback(nodes.last!.getOutput(index: executionIndex))
+                runningCount -= 1
             }
         }
     }
@@ -291,6 +317,20 @@ public class Network {
     func startNode(for name: String) -> Start? {
         return startNodes.first { $0.inputName == name }
     }
+
+    /// Blocking function that destroys resources and uninitializes the network. Should be called before a network is to be destroyed
+    /// but not from main thread
+    public func destroy() {
+        // Avoids new runs as side-effect
+        initialized = false
+        while runningCount > 0 {
+            usleep(10000) // 10ms
+        }
+        for node in nodes {
+            node.destroy()
+        }
+    }
+
 }
 
 //extension Network: GraphProtocol {}

--- a/Sources/Core/NetworkLayer.swift
+++ b/Sources/Core/NetworkLayer.swift
@@ -36,7 +36,7 @@ open class NetworkLayer: Node {
     public var outputSize: LayerSize!
 
     /// The result image of this layer
-    public var outputImage: MPSImage!
+    public var outputs: [MPSImage]
 
     /// points to the network where this layer is being executed
     public weak var network: Network?
@@ -52,6 +52,7 @@ open class NetworkLayer: Node {
             self.id = "Anonymous_\(NetworkLayer.counter)"
             NetworkLayer.counter += 1
         }
+        outputs = []
     }
 
     /// Validates the correctness of a layers inputs and parameters
@@ -63,8 +64,23 @@ open class NetworkLayer: Node {
         validate()
     }
 
+    public func createOutputs(size: LayerSize) {
+        guard let maxConcurrentExecutions = network?.maxConcurrentExecutions,
+                maxConcurrentExecutions > 0 else {
+            return
+        }
+        for _ in 0..<maxConcurrentExecutions {
+            outputs.append(MPSImage(device: Device.shared, imageDescriptor: MPSImageDescriptor(layerSize: size)))
+        }
+
+    }
+
     /// Runs the layer
-    open func execute(commandBuffer: MTLCommandBuffer) {
+    ///
+    /// - Parameters:
+    ///   - commandBuffer: MTLCommandBuffer that will run the layer
+    ///   - executionIndex: Execution index for concurrent executions. Index for output images
+    open func execute(commandBuffer: MTLCommandBuffer, executionIndex: Int = 0) {
         fatalError("Not implemented")
     }
 

--- a/Sources/Graph/Node.swift
+++ b/Sources/Graph/Node.swift
@@ -57,6 +57,8 @@ public extension Node {
             edgeIn[index] = captureWeakly(object: new)
             if let outIndex = new.edgeOut.index(where: { $0.isEqual(to: old)}) {
                 new.edgeOut[outIndex] = self
+            } else {
+                new.edgeOut.append(self)
             }
         }
     }

--- a/Sources/Helpers/MPSImageDescriptor.swift
+++ b/Sources/Helpers/MPSImageDescriptor.swift
@@ -20,4 +20,11 @@ public extension MPSImage {
     var size: LayerSize {
         return LayerSize(h: height, w: width, f: featureChannels)
     }
+
+    func setRead() {
+        if let `self` = self as? MPSTemporaryImage, self.readCount != 0 {
+            self.readCount -= 1
+        }
+    }
+
 }

--- a/Sources/Layers/Add.swift
+++ b/Sources/Layers/Add.swift
@@ -22,30 +22,34 @@ open class Add: NetworkLayer {
         assert(incoming[0].outputSize == incoming[1].outputSize, "Add only works for two layers of the same size")
     }
 
-    open override func initialize(network: Network, device: MTLDevice) {
-        super.initialize(network: network, device: device)
+    open override func initialize(network: Network, device: MTLDevice, temporaryImage: Bool = true) {
+        super.initialize(network: network, device: device, temporaryImage: temporaryImage)
 
         let incoming = getIncoming()
         outputSize = incoming[0].outputSize
         pipelineAdd = MetalShaderManager.shared.getFunction(name: "sum_matrix" + (outputSize.f > 4 ? "" : "_3"), in: Bundle(for: Add.self))
 
-        createOutputs(size: outputSize)
+        createOutputs(size: outputSize, temporary: temporaryImage)
     }
 
-    open override func execute(commandBuffer: MTLCommandBuffer, executionIndex: Int = 0) {
+    open override func execute(commandBuffer: MTLCommandBuffer, executionIndex index: Int = 0) {
         let incoming = getIncoming()
+        let input1 = incoming[0].getOutput(index: index)
+        let input2 = incoming[1].getOutput(index: index)
         let commandEncoder = commandBuffer.makeComputeCommandEncoder()!
         commandEncoder.label = "sum matrix encoder"
         // mean calculation 1st step
         let tpTG = MTLSizeMake(32, 8, 1)
         commandEncoder.setComputePipelineState(pipelineAdd)
-
-        commandEncoder.setTexture(incoming[0].outputs[executionIndex].texture, index: 0)
-        commandEncoder.setTexture(incoming[1].outputs[executionIndex].texture, index: 1)
-        commandEncoder.setTexture(outputs[executionIndex].texture, index: 2)
-        let threadgroupsPerGrid = incoming[0].outputs[executionIndex].texture.threadGrid(threadGroup: tpTG)
+        commandEncoder.setTexture(input1.texture, index: 0)
+        commandEncoder.setTexture(input2.texture, index: 1)
+        commandEncoder.setTexture(getOrCreateOutput(commandBuffer: commandBuffer, index: index).texture, index: 2)
+        let threadgroupsPerGrid = input1.texture.threadGrid(threadGroup: tpTG)
         commandEncoder.dispatchThreadgroups(threadgroupsPerGrid, threadsPerThreadgroup: tpTG)
         commandEncoder.endEncoding()
+
+        input1.setRead()
+        input2.setRead()
     }
 
 }

--- a/Sources/Layers/BGRAtoRGBA.swift
+++ b/Sources/Layers/BGRAtoRGBA.swift
@@ -29,17 +29,17 @@ open class BGRAtoRGBA: NetworkLayer {
         super.initialize(network: network, device: device)
         let incoming = getIncoming()
         outputSize = incoming[0].outputSize
-        outputImage = MPSImage(device: device, imageDescriptor: MPSImageDescriptor(layerSize: outputSize))
+        createOutputs(size: outputSize)
     }
 
-    open override func execute(commandBuffer: MTLCommandBuffer) {
+    open override func execute(commandBuffer: MTLCommandBuffer, executionIndex: Int = 0) {
         let encoder = commandBuffer.makeComputeCommandEncoder()!
         encoder.label = "BGRA to RGBA encoder"
         encoder.setComputePipelineState(pipelineBGRAtoRGBA)
-        encoder.setTexture(getIncoming()[0].outputImage.texture, index: 0)
-        encoder.setTexture(outputImage.texture, index: 1)
+        encoder.setTexture(getIncoming()[0].outputs[executionIndex].texture, index: 0)
+        encoder.setTexture(outputs[executionIndex].texture, index: 1)
         let threadsPerGroups = MTLSizeMake(32, 8, 1)
-        let threadGroups = outputImage.texture.threadGrid(threadGroup: threadsPerGroups)
+        let threadGroups = outputs[executionIndex].texture.threadGrid(threadGroup: threadsPerGroups)
         encoder.dispatchThreadgroups(threadGroups, threadsPerThreadgroup: threadsPerGroups)
         encoder.endEncoding()
     }

--- a/Sources/Layers/BGRAtoRGBA.swift
+++ b/Sources/Layers/BGRAtoRGBA.swift
@@ -25,23 +25,28 @@ open class BGRAtoRGBA: NetworkLayer {
         assert(incoming.count == 1, "BGRAtoRGBA supports one input, not \(incoming.count)")
     }
 
-    open override func initialize(network: Network, device: MTLDevice) {
-        super.initialize(network: network, device: device)
+    open override func initialize(network: Network, device: MTLDevice, temporaryImage: Bool = true) {
+        super.initialize(network: network, device: device, temporaryImage: temporaryImage)
         let incoming = getIncoming()
         outputSize = incoming[0].outputSize
-        createOutputs(size: outputSize)
+        createOutputs(size: outputSize, temporary: temporaryImage)
     }
 
-    open override func execute(commandBuffer: MTLCommandBuffer, executionIndex: Int = 0) {
+    open override func execute(commandBuffer: MTLCommandBuffer, executionIndex index: Int = 0) {
+        let input = getIncoming()[0].getOutput(index: index)
+        let output = getOrCreateOutput(commandBuffer: commandBuffer, index: index)
+
         let encoder = commandBuffer.makeComputeCommandEncoder()!
         encoder.label = "BGRA to RGBA encoder"
         encoder.setComputePipelineState(pipelineBGRAtoRGBA)
-        encoder.setTexture(getIncoming()[0].outputs[executionIndex].texture, index: 0)
-        encoder.setTexture(outputs[executionIndex].texture, index: 1)
+        encoder.setTexture(input.texture, index: 0)
+        encoder.setTexture(output.texture, index: 1)
         let threadsPerGroups = MTLSizeMake(32, 8, 1)
-        let threadGroups = outputs[executionIndex].texture.threadGrid(threadGroup: threadsPerGroups)
+        let threadGroups = output.texture.threadGrid(threadGroup: threadsPerGroups)
         encoder.dispatchThreadgroups(threadGroups, threadsPerThreadgroup: threadsPerGroups)
         encoder.endEncoding()
+
+        input.setRead()
     }
 
 }

--- a/Sources/Layers/BatchNorm.swift
+++ b/Sources/Layers/BatchNorm.swift
@@ -58,8 +58,8 @@ open class BatchNorm: NetworkLayer {
         assert(incoming.count == 1, "BatchNorm must have one input, not \(incoming.count)")
     }
 
-    open override func initialize(network: Network, device: MTLDevice) {
-        super.initialize(network: network, device: device)
+    open override func initialize(network: Network, device: MTLDevice, temporaryImage: Bool = true) {
+        super.initialize(network: network, device: device, temporaryImage: temporaryImage)
         let incoming = getIncoming()
         outputSize = incoming[0].outputSize
 
@@ -88,20 +88,24 @@ open class BatchNorm: NetworkLayer {
                                             length: (max(4, outputSize.f) * 4 + 1) * Constants.HalfSize,
                                             options: [])
         }
-        createOutputs(size: outputSize)
+        createOutputs(size: outputSize, temporary: temporaryImage)
     }
 
-    open override func execute(commandBuffer: MTLCommandBuffer, executionIndex: Int = 0) {
+    open override func execute(commandBuffer: MTLCommandBuffer, executionIndex index: Int = 0) {
+        let input = getIncoming()[0].getOutput(index: index)
+        let output = getOrCreateOutput(commandBuffer: commandBuffer, index: index)
         let encoder = commandBuffer.makeComputeCommandEncoder()!
         encoder.label = "Batch Norm encoder"
         encoder.setComputePipelineState(kernel)
-        encoder.setTexture(getIncoming()[0].outputs[executionIndex].texture, index: 0)
-        encoder.setTexture(outputs[executionIndex].texture, index: 1)
+        encoder.setTexture(input.texture, index: 0)
+        encoder.setTexture(output.texture, index: 1)
 
         encoder.setBuffer(paramBuffer, offset: 0, index: 0)
         let threadsPerGroups = MTLSizeMake(32, 8, 1)
-        let threadGroups = outputs[executionIndex].texture.threadGrid(threadGroup: threadsPerGroups)
+        let threadGroups = output.texture.threadGrid(threadGroup: threadsPerGroups)
         encoder.dispatchThreadgroups(threadGroups, threadsPerThreadgroup: threadsPerGroups)
         encoder.endEncoding()
+
+        input.setRead()
     }
 }

--- a/Sources/Layers/Convolution.swift
+++ b/Sources/Layers/Convolution.swift
@@ -66,7 +66,7 @@ open class Convolution: NetworkLayer {
             conv?.offset = MPSOffset(x: Int(convSize.kernelWidth)/2, y: Int(convSize.kernelHeight)/2, z: 0)
         }
 
-        outputImage = MPSImage(device: device, imageDescriptor: MPSImageDescriptor(layerSize: outputSize))
+        createOutputs(size: outputSize)
     }
 
     open func getWeightsSize() -> Int {
@@ -117,10 +117,10 @@ open class Convolution: NetworkLayer {
                                  flags: .none)
     }
 
-    open override func execute(commandBuffer: MTLCommandBuffer) {
+    open override func execute(commandBuffer: MTLCommandBuffer, executionIndex: Int = 0) {
         conv?.encode(commandBuffer: commandBuffer,
-                     sourceImage: getIncoming()[0].outputImage,
-                     destinationImage: outputImage)
+                     sourceImage: getIncoming()[0].outputs[executionIndex],
+                     destinationImage: outputs[executionIndex])
     }
 
 }

--- a/Sources/Layers/Crop.swift
+++ b/Sources/Layers/Crop.swift
@@ -15,7 +15,11 @@ open class Crop: NetworkLayer {
     public init(device: MTLDevice, croppedSize: LayerSize, id: String? = nil) {
         super.init(id: id)
         outputSize = croppedSize
-        createOutputs(size: outputSize)
+    }
+
+    open override func initialize(network: Network, device: MTLDevice, temporaryImage: Bool = true) {
+        super.initialize(network: network, device: device, temporaryImage: temporaryImage)
+        createOutputs(size: outputSize, temporary: temporaryImage)
     }
 
     open override func validate() {
@@ -23,15 +27,15 @@ open class Crop: NetworkLayer {
         assert(incoming.count == 1, "Crop must have one input, not \(incoming.count)")
     }
 
-    open override func execute(commandBuffer: MTLCommandBuffer, executionIndex: Int = 0) {
-        let input = getIncoming()[0].outputs[executionIndex]
+    open override func execute(commandBuffer: MTLCommandBuffer, executionIndex index: Int = 0) {
+        let input = getIncoming()[0].getOutput(index: index)
         let blitEncoder = commandBuffer.makeBlitCommandEncoder()!
         blitEncoder.copy(from: input.texture, sourceSlice: 0, sourceLevel: 0,
                          sourceOrigin: MTLOrigin(x: (input.width - outputSize.w) / 2,
                                                  y: (input.height - outputSize.h) / 2,
                                                  z: 0),
                          sourceSize: MTLSizeMake(outputSize.w, outputSize.h, 1),
-                         to: outputs[executionIndex].texture, destinationSlice: 0, destinationLevel: 0,
+                         to: getOrCreateOutput(commandBuffer: commandBuffer, index: index).texture, destinationSlice: 0, destinationLevel: 0,
                          destinationOrigin: MTLOrigin(x: 0, y: 0, z: 0))
         blitEncoder.endEncoding()
     }

--- a/Sources/Layers/Crop.swift
+++ b/Sources/Layers/Crop.swift
@@ -14,8 +14,8 @@ open class Crop: NetworkLayer {
 
     public init(device: MTLDevice, croppedSize: LayerSize, id: String? = nil) {
         super.init(id: id)
-        self.outputSize = croppedSize
-        self.outputImage = MPSImage(device: device, imageDescriptor: MPSImageDescriptor(layerSize: croppedSize))
+        outputSize = croppedSize
+        createOutputs(size: outputSize)
     }
 
     open override func validate() {
@@ -23,15 +23,15 @@ open class Crop: NetworkLayer {
         assert(incoming.count == 1, "Crop must have one input, not \(incoming.count)")
     }
 
-    open override func execute(commandBuffer: MTLCommandBuffer) {
-        let input = getIncoming()[0].outputImage!
+    open override func execute(commandBuffer: MTLCommandBuffer, executionIndex: Int = 0) {
+        let input = getIncoming()[0].outputs[executionIndex]
         let blitEncoder = commandBuffer.makeBlitCommandEncoder()!
         blitEncoder.copy(from: input.texture, sourceSlice: 0, sourceLevel: 0,
                          sourceOrigin: MTLOrigin(x: (input.width - outputSize.w) / 2,
                                                  y: (input.height - outputSize.h) / 2,
                                                  z: 0),
                          sourceSize: MTLSizeMake(outputSize.w, outputSize.h, 1),
-                         to: outputImage.texture, destinationSlice: 0, destinationLevel: 0,
+                         to: outputs[executionIndex].texture, destinationSlice: 0, destinationLevel: 0,
                          destinationOrigin: MTLOrigin(x: 0, y: 0, z: 0))
         blitEncoder.endEncoding()
     }

--- a/Sources/Layers/DepthwiseConvolution.swift
+++ b/Sources/Layers/DepthwiseConvolution.swift
@@ -21,10 +21,6 @@ open class DepthwiseConvolution: Convolution {
         return prevSize.f * convSize.kernelHeight * convSize.kernelWidth
     }
 
-    open override func updatedCheckpoint(device: MTLDevice) {
-        updateWeights(device: device)
-    }
-
     open override func makeConv(device: MTLDevice, weights: UnsafePointer<Float>, bias: UnsafePointer<Float>?) {
         let desc = MPSCNNDepthWiseConvolutionDescriptor(
             kernelWidth: convSize.kernelWidth,
@@ -43,12 +39,6 @@ open class DepthwiseConvolution: Convolution {
                                  kernelWeights: weights,
                                  biasTerms: bias,
                                  flags: .none)
-    }
-
-    open override func execute(commandBuffer: MTLCommandBuffer, executionIndex: Int = 0) {
-        conv?.encode(commandBuffer: commandBuffer,
-                     sourceImage: getIncoming()[0].outputs[executionIndex],
-                     destinationImage: outputs[executionIndex])
     }
 
 }

--- a/Sources/Layers/DepthwiseConvolution.swift
+++ b/Sources/Layers/DepthwiseConvolution.swift
@@ -45,10 +45,10 @@ open class DepthwiseConvolution: Convolution {
                                  flags: .none)
     }
 
-    open override func execute(commandBuffer: MTLCommandBuffer) {
+    open override func execute(commandBuffer: MTLCommandBuffer, executionIndex: Int = 0) {
         conv?.encode(commandBuffer: commandBuffer,
-                     sourceImage: getIncoming()[0].outputImage,
-                     destinationImage: outputImage)
+                     sourceImage: getIncoming()[0].outputs[executionIndex],
+                     destinationImage: outputs[executionIndex])
     }
 
 }

--- a/Sources/Layers/Dummy.swift
+++ b/Sources/Layers/Dummy.swift
@@ -13,7 +13,7 @@ open class Dummy: NetworkLayer {
 
     // Dummy layers should be removed after initialize
     // Assign inputs to outputs and vice versa
-    open override func initialize(network: Network, device: MTLDevice) {
+    open override func initialize(network: Network, device: MTLDevice, temporaryImage: Bool = true) {
         super.initialize(network: network, device: device)
         removeFromGraph()
     }

--- a/Sources/Layers/Dummy.swift
+++ b/Sources/Layers/Dummy.swift
@@ -18,7 +18,7 @@ open class Dummy: NetworkLayer {
         removeFromGraph()
     }
 
-    open override func execute(commandBuffer: MTLCommandBuffer) {
+    open override func execute(commandBuffer: MTLCommandBuffer, executionIndex: Int = 0) {
         fatalError("Dummy in execution list")
     }
 

--- a/Sources/Layers/FullyConnected.swift
+++ b/Sources/Layers/FullyConnected.swift
@@ -45,7 +45,7 @@ open class FullyConnected: NetworkLayer {
         assert(incoming.count == 1, "Fully Connected must have one input, not \(incoming.count)")
     }
 
-    open override func initialize(network: Network, device: MTLDevice) {
+    open override func initialize(network: Network, device: MTLDevice, temporaryImage: Bool = true) {
         super.initialize(network: network, device: device)
         let incoming = getIncoming()
         prevSize = incoming.first?.outputSize
@@ -56,7 +56,7 @@ open class FullyConnected: NetworkLayer {
         }
 
         updateWeights(device: device)
-        createOutputs(size: outputSize)
+        createOutputs(size: outputSize, temporary: temporaryImage)
     }
 
     open func getWeightsSize() -> Int {
@@ -100,10 +100,10 @@ open class FullyConnected: NetworkLayer {
                                       flags: .none)
     }
 
-    open override func execute(commandBuffer: MTLCommandBuffer, executionIndex: Int = 0) {
+    open override func execute(commandBuffer: MTLCommandBuffer, executionIndex index: Int = 0) {
         kernel?.encode(commandBuffer: commandBuffer,
-                       sourceImage: getIncoming()[0].outputs[executionIndex],
-                       destinationImage: outputs[executionIndex])
+                       sourceImage: getIncoming()[0].getOutput(index: index),
+                       destinationImage: getOrCreateOutput(commandBuffer: commandBuffer, index: index))
     }
 
 }

--- a/Sources/Layers/FullyConnected.swift
+++ b/Sources/Layers/FullyConnected.swift
@@ -56,7 +56,7 @@ open class FullyConnected: NetworkLayer {
         }
 
         updateWeights(device: device)
-        outputImage = MPSImage(device: device, imageDescriptor: MPSImageDescriptor(layerSize: outputSize))
+        createOutputs(size: outputSize)
     }
 
     open func getWeightsSize() -> Int {
@@ -100,10 +100,10 @@ open class FullyConnected: NetworkLayer {
                                       flags: .none)
     }
 
-    open override func execute(commandBuffer: MTLCommandBuffer) {
+    open override func execute(commandBuffer: MTLCommandBuffer, executionIndex: Int = 0) {
         kernel?.encode(commandBuffer: commandBuffer,
-                       sourceImage: getIncoming()[0].outputImage,
-                       destinationImage: outputImage)
+                       sourceImage: getIncoming()[0].outputs[executionIndex],
+                       destinationImage: outputs[executionIndex])
     }
 
 }

--- a/Sources/Layers/Identity.swift
+++ b/Sources/Layers/Identity.swift
@@ -16,14 +16,14 @@ open class Identity: NetworkLayer {
         assert(incoming.count == 1, "Identity must have one input, not \(incoming.count)")
     }
 
-    open override func initialize(network: Network, device: MTLDevice) {
-        super.initialize(network: network, device: device)
+    open override func initialize(network: Network, device: MTLDevice, temporaryImage: Bool = true) {
+        super.initialize(network: network, device: device, temporaryImage: temporaryImage)
         let incoming = getIncoming()
         outputSize = incoming[0].outputSize
     }
 
     open override func execute(commandBuffer: MTLCommandBuffer, executionIndex: Int = 0) {
-        outputs[executionIndex] = getIncoming()[0].outputs[executionIndex]
+        rewireIdentity(at: executionIndex, image: getIncoming()[0].getOutput(index: executionIndex))
     }
 
 }

--- a/Sources/Layers/Identity.swift
+++ b/Sources/Layers/Identity.swift
@@ -22,8 +22,8 @@ open class Identity: NetworkLayer {
         outputSize = incoming[0].outputSize
     }
 
-    open override func execute(commandBuffer: MTLCommandBuffer) {
-        outputImage = getIncoming()[0].outputImage
+    open override func execute(commandBuffer: MTLCommandBuffer, executionIndex: Int = 0) {
+        outputs[executionIndex] = getIncoming()[0].outputs[executionIndex]
     }
 
 }

--- a/Sources/Layers/ImageLinearTransform.swift
+++ b/Sources/Layers/ImageLinearTransform.swift
@@ -40,17 +40,17 @@ open class ImageLinearTransform: NetworkLayer {
                                                          constants: [FunctionConstant<Float>(index: 0, type: MTLDataType.float, value: scale),
                                                                      FunctionConstant<Float>(index: 1, type: MTLDataType.float, value: shift)])
 
-        outputImage = MPSImage(device: device, imageDescriptor: MPSImageDescriptor(layerSize: outputSize))
+        createOutputs(size: outputSize)
     }
 
-    open override func execute(commandBuffer: MTLCommandBuffer) {
+    open override func execute(commandBuffer: MTLCommandBuffer, executionIndex: Int = 0) {
         let encoder = commandBuffer.makeComputeCommandEncoder()!
         encoder.label = "Scale to Image encoder"
         encoder.setComputePipelineState(pipeline)
-        encoder.setTexture(getIncoming()[0].outputImage.texture, index: 0)
-        encoder.setTexture(outputImage.texture, index: 1)
+        encoder.setTexture(getIncoming()[0].outputs[executionIndex].texture, index: 0)
+        encoder.setTexture(outputs[executionIndex].texture, index: 1)
         let threadsPerGroups = MTLSizeMake(32, 8, 1)
-        let threadGroups = outputImage.texture.threadGrid(threadGroup: threadsPerGroups)
+        let threadGroups = outputs[executionIndex].texture.threadGrid(threadGroup: threadsPerGroups)
         encoder.dispatchThreadgroups(threadGroups, threadsPerThreadgroup: threadsPerGroups)
         encoder.endEncoding()
     }

--- a/Sources/Layers/Neuron.swift
+++ b/Sources/Layers/Neuron.swift
@@ -37,10 +37,10 @@ open class Neuron: NetworkLayer {
         outputSize = incoming[0].outputSize
 
         self.neuron = type.createNeuron(device: device)
-        outputImage = MPSImage(device: device, imageDescriptor: MPSImageDescriptor(layerSize: outputSize))
+        createOutputs(size: outputSize)
     }
 
-    open override func execute(commandBuffer: MTLCommandBuffer) {
-        neuron.encode(commandBuffer: commandBuffer, sourceImage: getIncoming()[0].outputImage, destinationImage: outputImage)
+    open override func execute(commandBuffer: MTLCommandBuffer, executionIndex: Int = 0) {
+        neuron.encode(commandBuffer: commandBuffer, sourceImage: getIncoming()[0].outputs[executionIndex], destinationImage: outputs[executionIndex])
     }
 }

--- a/Sources/Layers/Neuron.swift
+++ b/Sources/Layers/Neuron.swift
@@ -31,16 +31,18 @@ open class Neuron: NetworkLayer {
         assert(incoming.count == 1, "Neuron must have one input, not \(incoming.count)")
     }
 
-    open override func initialize(network: Network, device: MTLDevice) {
-        super.initialize(network: network, device: device)
+    open override func initialize(network: Network, device: MTLDevice, temporaryImage: Bool = true) {
+        super.initialize(network: network, device: device, temporaryImage: temporaryImage)
         let incoming = getIncoming()
         outputSize = incoming[0].outputSize
 
         self.neuron = type.createNeuron(device: device)
-        createOutputs(size: outputSize)
+        createOutputs(size: outputSize, temporary: temporaryImage)
     }
 
     open override func execute(commandBuffer: MTLCommandBuffer, executionIndex: Int = 0) {
-        neuron.encode(commandBuffer: commandBuffer, sourceImage: getIncoming()[0].outputs[executionIndex], destinationImage: outputs[executionIndex])
+        neuron.encode(commandBuffer: commandBuffer,
+                      sourceImage: getIncoming()[0].getOutput(index: executionIndex),
+                      destinationImage: getOrCreateOutput(commandBuffer: commandBuffer, index: executionIndex))
     }
 }

--- a/Sources/Layers/Pooling.swift
+++ b/Sources/Layers/Pooling.swift
@@ -79,11 +79,11 @@ open class Pooling: NetworkLayer {
                                    f: prevSize.f)
         }
 
-        outputImage = MPSImage(device: device, imageDescriptor: MPSImageDescriptor(layerSize: outputSize))
+        createOutputs(size: outputSize)
     }
 
-    open override func execute(commandBuffer: MTLCommandBuffer) {
-        pooling.encode(commandBuffer: commandBuffer, sourceImage: getIncoming()[0].outputImage, destinationImage: outputImage)
+    open override func execute(commandBuffer: MTLCommandBuffer, executionIndex: Int = 0) {
+        pooling.encode(commandBuffer: commandBuffer, sourceImage: getIncoming()[0].outputs[executionIndex], destinationImage: outputs[executionIndex])
     }
 
 }

--- a/Sources/Layers/Pooling.swift
+++ b/Sources/Layers/Pooling.swift
@@ -41,8 +41,8 @@ open class Pooling: NetworkLayer {
         assert(incoming.count == 1, "Pooling must have one input, not \(incoming.count)")
     }
 
-    open override func initialize(network: Network, device: MTLDevice) {
-        super.initialize(network: network, device: device)
+    open override func initialize(network: Network, device: MTLDevice, temporaryImage: Bool = true) {
+        super.initialize(network: network, device: device, temporaryImage: temporaryImage)
         let incoming = getIncoming()
         let prevSize = incoming[0].outputSize!
 
@@ -79,11 +79,13 @@ open class Pooling: NetworkLayer {
                                    f: prevSize.f)
         }
 
-        createOutputs(size: outputSize)
+        createOutputs(size: outputSize, temporary: temporaryImage)
     }
 
-    open override func execute(commandBuffer: MTLCommandBuffer, executionIndex: Int = 0) {
-        pooling.encode(commandBuffer: commandBuffer, sourceImage: getIncoming()[0].outputs[executionIndex], destinationImage: outputs[executionIndex])
+    open override func execute(commandBuffer: MTLCommandBuffer, executionIndex index: Int = 0) {
+        pooling.encode(commandBuffer: commandBuffer,
+                       sourceImage: getIncoming()[0].getOutput(index: index),
+                       destinationImage: getOrCreateOutput(commandBuffer: commandBuffer, index: index))
     }
 
 }

--- a/Sources/Layers/Scale.swift
+++ b/Sources/Layers/Scale.swift
@@ -27,10 +27,10 @@ open class Scale: NetworkLayer {
     open override func initialize(network: Network, device: MTLDevice) {
         super.initialize(network: network, device: device)
         lanczos = MPSImageLanczosScale(device: device)
-        outputImage = MPSImage(device: device, imageDescriptor: MPSImageDescriptor(layerSize: outputSize))
+        createOutputs(size: outputSize)
     }
 
-    open override func execute(commandBuffer: MTLCommandBuffer) {
-        lanczos.encode(commandBuffer: commandBuffer, sourceTexture: getIncoming()[0].outputImage.texture, destinationTexture: outputImage.texture)
+    open override func execute(commandBuffer: MTLCommandBuffer, executionIndex: Int = 0) {
+        lanczos.encode(commandBuffer: commandBuffer, sourceTexture: getIncoming()[0].outputs[executionIndex].texture, destinationTexture: outputs[executionIndex].texture)
     }
 }

--- a/Sources/Layers/Scale.swift
+++ b/Sources/Layers/Scale.swift
@@ -24,13 +24,18 @@ open class Scale: NetworkLayer {
         assert(incoming.count == 1, "Scale must have one input, not \(incoming.count)")
     }
 
-    open override func initialize(network: Network, device: MTLDevice) {
-        super.initialize(network: network, device: device)
+    open override func initialize(network: Network, device: MTLDevice, temporaryImage: Bool = true) {
+        super.initialize(network: network, device: device, temporaryImage: temporaryImage)
         lanczos = MPSImageLanczosScale(device: device)
-        createOutputs(size: outputSize)
+        createOutputs(size: outputSize, temporary: true)
     }
 
-    open override func execute(commandBuffer: MTLCommandBuffer, executionIndex: Int = 0) {
-        lanczos.encode(commandBuffer: commandBuffer, sourceTexture: getIncoming()[0].outputs[executionIndex].texture, destinationTexture: outputs[executionIndex].texture)
+    open override func execute(commandBuffer: MTLCommandBuffer, executionIndex index: Int = 0) {
+        let input = getIncoming()[0].getOutput(index: index)
+        let output = getOrCreateOutput(commandBuffer: commandBuffer, index: index)
+        lanczos.encode(commandBuffer: commandBuffer,
+                       sourceTexture: input.texture,
+                       destinationTexture: output.texture)
+        input.setRead()
     }
 }

--- a/Sources/Layers/Softmax.swift
+++ b/Sources/Layers/Softmax.swift
@@ -19,16 +19,18 @@ open class Softmax: NetworkLayer {
         assert(incoming.count == 1, "SoftMax must have one input, not \(incoming.count)")
     }
 
-    open override func initialize(network: Network, device: MTLDevice) {
-        super.initialize(network: network, device: device)
+    open override func initialize(network: Network, device: MTLDevice, temporaryImage: Bool = true) {
+        super.initialize(network: network, device: device, temporaryImage: temporaryImage)
         let incoming = getIncoming()
         outputSize = incoming[0].outputSize
 
         kernel = MPSCNNSoftMax(device: device)
-        createOutputs(size: outputSize)
+        createOutputs(size: outputSize, temporary: temporaryImage)
     }
 
-    open override func execute(commandBuffer: MTLCommandBuffer, executionIndex: Int = 0) {
-        kernel.encode(commandBuffer: commandBuffer, sourceImage: getIncoming()[0].outputs[executionIndex], destinationImage: outputs[executionIndex])
+    open override func execute(commandBuffer: MTLCommandBuffer, executionIndex index: Int = 0) {
+        kernel.encode(commandBuffer: commandBuffer,
+                      sourceImage: getIncoming()[0].getOutput(index: index),
+                      destinationImage: getOrCreateOutput(commandBuffer: commandBuffer, index: index))
     }
 }

--- a/Sources/Layers/Softmax.swift
+++ b/Sources/Layers/Softmax.swift
@@ -25,10 +25,10 @@ open class Softmax: NetworkLayer {
         outputSize = incoming[0].outputSize
 
         kernel = MPSCNNSoftMax(device: device)
-        outputImage = MPSImage(device: device, imageDescriptor: MPSImageDescriptor(layerSize: outputSize))
+        createOutputs(size: outputSize)
     }
 
-    open override func execute(commandBuffer: MTLCommandBuffer) {
-        kernel.encode(commandBuffer: commandBuffer, sourceImage: getIncoming()[0].outputImage, destinationImage: outputImage)
+    open override func execute(commandBuffer: MTLCommandBuffer, executionIndex: Int = 0) {
+        kernel.encode(commandBuffer: commandBuffer, sourceImage: getIncoming()[0].outputs[executionIndex], destinationImage: outputs[executionIndex])
     }
 }

--- a/Sources/Layers/SpatialNorm.swift
+++ b/Sources/Layers/SpatialNorm.swift
@@ -40,14 +40,14 @@ open class SpatialNorm: NetworkLayer {
         outputSize = incoming[0].outputSize
 
         kernel = MPSCNNSpatialNormalization(device: device, kernelWidth: kWidth, kernelHeight: kHeight)
-        outputImage = MPSImage(device: device, imageDescriptor: MPSImageDescriptor(layerSize: outputSize))
+        createOutputs(size: outputSize)
 
         if let alpha = alpha { kernel.alpha = alpha }
         if let beta = beta { kernel.beta = beta }
         if let delta = delta { kernel.delta = delta }
     }
 
-    open override func execute(commandBuffer: MTLCommandBuffer) {
-        kernel.encode(commandBuffer: commandBuffer, sourceImage: getIncoming()[0].outputImage, destinationImage: outputImage)
+    open override func execute(commandBuffer: MTLCommandBuffer, executionIndex: Int = 0) {
+        kernel.encode(commandBuffer: commandBuffer, sourceImage: getIncoming()[0].outputs[executionIndex], destinationImage: outputs[executionIndex])
     }
 }

--- a/Sources/Layers/SpatialNorm.swift
+++ b/Sources/Layers/SpatialNorm.swift
@@ -34,20 +34,22 @@ open class SpatialNorm: NetworkLayer {
         assert(incoming.count == 1, "SpatialNorm must have one input, not \(incoming.count)")
     }
 
-    open override func initialize(network: Network, device: MTLDevice) {
-        super.initialize(network: network, device: device)
+    open override func initialize(network: Network, device: MTLDevice, temporaryImage: Bool = true) {
+        super.initialize(network: network, device: device, temporaryImage: temporaryImage)
         let incoming = getIncoming()
         outputSize = incoming[0].outputSize
 
         kernel = MPSCNNSpatialNormalization(device: device, kernelWidth: kWidth, kernelHeight: kHeight)
-        createOutputs(size: outputSize)
+        createOutputs(size: outputSize, temporary: temporaryImage)
 
         if let alpha = alpha { kernel.alpha = alpha }
         if let beta = beta { kernel.beta = beta }
         if let delta = delta { kernel.delta = delta }
     }
 
-    open override func execute(commandBuffer: MTLCommandBuffer, executionIndex: Int = 0) {
-        kernel.encode(commandBuffer: commandBuffer, sourceImage: getIncoming()[0].outputs[executionIndex], destinationImage: outputs[executionIndex])
+    open override func execute(commandBuffer: MTLCommandBuffer, executionIndex index: Int = 0) {
+        kernel.encode(commandBuffer: commandBuffer,
+                      sourceImage: getIncoming()[0].getOutput(index: index),
+                      destinationImage: getOrCreateOutput(commandBuffer: commandBuffer, index: index))
     }
 }

--- a/Sources/Layers/Start.swift
+++ b/Sources/Layers/Start.swift
@@ -14,7 +14,6 @@ open class Start: NetworkLayer {
 
     open var inputImage: MPSImage!
     open var lanczos: MPSImageLanczosScale!
-    open var croppedImg: MPSImage!
     var inputName: String
 
     public init(size: LayerSize, inputName: String = "") {
@@ -26,24 +25,22 @@ open class Start: NetworkLayer {
     open override func initialize(network: Network, device: MTLDevice) {
         super.initialize(network: network, device: device)
         lanczos = MPSImageLanczosScale(device: device)
-        croppedImg = MPSImage(device: device, imageDescriptor: MPSImageDescriptor(layerSize: outputSize))
+        createOutputs(size: outputSize)
     }
 
-    open override func execute(commandBuffer: MTLCommandBuffer) {
+    open override func execute(commandBuffer: MTLCommandBuffer, executionIndex: Int = 0) {
         if inputImage.size == outputSize {
-            outputImage = inputImage
+            outputs[executionIndex] = inputImage
             return
         }
 
         // If the inputImage does not have the requested output size then we have to resize it.
-
-        outputImage = croppedImg
         let inputAspect = Double(inputImage.width) / Double(inputImage.height)
         let aspect = inputAspect - (Double(outputSize.w) / Double(outputSize.h))
         var scaledW: Int
         var scaledH: Int
         if aspect == 0.0 { // input and output aspect ratio are equal
-            lanczos.encode(commandBuffer: commandBuffer, sourceTexture: inputImage.texture, destinationTexture: croppedImg.texture)
+            lanczos.encode(commandBuffer: commandBuffer, sourceTexture: inputImage.texture, destinationTexture: outputs[executionIndex].texture)
             return
         } else if aspect > 0.0 { // input aspect ratio greater than output aspect ratio
             scaledH = outputSize.h
@@ -67,8 +64,8 @@ open class Start: NetworkLayer {
                          sourceOrigin: MTLOrigin(x: (scaledW - outputSize.w) / 2,
                                                  y: (scaledH - outputSize.h) / 2,
                                                  z: 0),
-                         sourceSize: MTLSizeMake(croppedImg.width, croppedImg.height, 1),
-                         to: croppedImg.texture, destinationSlice: 0, destinationLevel: 0,
+                         sourceSize: MTLSizeMake(outputs[executionIndex].width, outputs[executionIndex].height, 1),
+                         to: outputs[executionIndex].texture, destinationSlice: 0, destinationLevel: 0,
                          destinationOrigin: MTLOrigin(x: 0, y: 0, z: 0))
         blitEncoder.endEncoding()
 

--- a/Sources/Metal/instanceNorm3.metal
+++ b/Sources/Metal/instanceNorm3.metal
@@ -9,8 +9,8 @@
 #include <metal_stdlib>
 using namespace metal;
 
-kernel void instance_norm_3(constant float4 &scale[[buffer(0)]],
-                            constant float4 &shift[[buffer(1)]],
+kernel void instance_norm_3(constant float* scale[[buffer(0)]],
+                            constant float* shift[[buffer(1)]],
                             texture2d<float, access::read> in[[texture(0)]],
                             texture2d<float, access::write> out[[texture(1)]],
                             ushort2 gid[[thread_position_in_grid]],
@@ -92,11 +92,11 @@ kernel void instance_norm_3(constant float4 &scale[[buffer(0)]],
 
     const float4 sigma = sqrt(shared_mem[0] + float4(1e-4));
 
-    float4 multiplier = scale / sigma;
+    float4 multiplier = float4(scale[0], scale[1], scale[2], scale[3]) / sigma;
     for(ushort xIndex = gid.x; xIndex < width; xIndex += tg_size.x) {
         for(ushort yIndex = gid.y; yIndex < height; yIndex += tg_size.y) {
             float4 val = in.read(ushort2(xIndex, yIndex));
-            out.write(clamp((val - mean) * multiplier + shift, -10.0, 10.0), ushort2(xIndex, yIndex));
+            out.write(clamp((val - mean) * multiplier + float4(shift[0], shift[1], shift[2], shift[3]), -10.0, 10.0), ushort2(xIndex, yIndex));
         }
     }
 }


### PR DESCRIPTION
> This PR has to be merged after #100 

Change MPSImage for MPSTemporaryImage but leaving open the possibility to have some layers with MPSImage output. 

This seems to greatly reduce the memory used by the GPU

