### PR TITLE
Use MPSCNNConvolutionTranspose in iOS 11.3.1 +

### DIFF
--- a/Sources/Adapters/Tensorflow/TFConverter+Mappers.swift
+++ b/Sources/Adapters/Tensorflow/TFConverter+Mappers.swift
@@ -101,8 +101,14 @@ public extension TFConverter {
             kernelHeight: weightData.weightShape.kernelHeight,
             strideX: Int(strides.x),
             strideY: Int(strides.y))
+
+        var weights = weightData.weights
+        if #available(iOS 11.3.1, *) {
+            // We use MPSCNNConvolutionTranspose in this case and must transpose the weights
+            weights = weightData.weights != nil ? permute(order: [2, 0, 1, 3])(weightData.weights!, weightData.weightShape.toShape) : nil
+        }
         return ConvTranspose(size: convSize,
-                             weights: weightData.weights,
+                             weights: weights,
                              bias: weightData.bias,
                              id: node.nodeDef.name)
     }

--- a/Sources/Layers/ConvTranspose.swift
+++ b/Sources/Layers/ConvTranspose.swift
@@ -19,16 +19,24 @@ open class ConvTranspose: NetworkLayer {
 
     /// Used to determine the filename for this layers weights. (Ignored if there is no ParameterLoader)
     static var weightModifier: String = ""
+    static var biasModifier: String = ""
     var weightsPointer: Data?
+    var biasPointer: Data?
+    var useBias: Bool
 
     let size: ConvSize
     private var prevSize: LayerSize!
 
+    // Own implementation
     var pipelineCalculate: MTLComputePipelineState!
     var pipelineShiftLeft: MTLComputePipelineState!
     var pipelineShiftTop: MTLComputePipelineState!
-
     var weightsBuffer: MTLBuffer!
+
+    // MPSCNN implementation
+    var cnnDescriptor: MPSCNNConvolutionDescriptor!
+    var dataSource: Any?
+    var conv: Any?
 
     /// ConvTranspoe initializer
     /// Note: padding is PaddingType.same
@@ -36,40 +44,29 @@ open class ConvTranspose: NetworkLayer {
     /// - Parameters:
     ///   - size: Convolution size
     ///   - weights: Convolution weights
-    ///   - bias: Convolution bias (not yet implemented)
+    ///   - bias: Convolution bias (only iOS 11.3.1+)
     ///   - id: Node identification string. Used to load weights if they are not frozen into the graph.
-    public init(size: ConvSize, weights: Data? = nil, bias: Data? = nil,
-                id: String? = nil) {
+    public init(size: ConvSize, weights: Data? = nil, bias: Data? = nil, useBias: Bool = false, id: String? = nil) {
         self.size = size
         self.weightsPointer = weights
+        self.biasPointer = bias
+        self.useBias = useBias
         super.init(id: id)
     }
 
     open override func validate() {
         let incoming = getIncoming()
         assert(incoming.count == 1, "ConvTranspose must have one input, not \(incoming.count)")
-        assert(size.strideX == size.strideY, "ConvTranspose must have symmetric strides") // restriction might be taken away
-        assert(size.kernelWidth == size.kernelHeight, "ConvTranspose must have symmetric kernel sizes") // restriction might be taken away
-        assert(size.strideX == size.kernelWidth - 1, "ConvTranspose: stride must be kernelSize - 1")
+        if #available(iOS 11.3.1, *) {} else {
+            assert(size.strideX == size.strideY, "ConvTranspose must have symmetric strides") // restriction might be taken away
+            assert(size.kernelWidth == size.kernelHeight, "ConvTranspose must have symmetric kernel sizes") // restriction might be taken away
+            assert(size.strideX == size.kernelWidth - 1, "ConvTranspose: stride must be kernelSize - 1")
+        }
     }
 
     open override func initialize(network: Network, device: MTLDevice, temporaryImage: Bool = true) {
         super.initialize(network: network, device: device, temporaryImage: temporaryImage)
         let incoming = getIncoming()
-
-        // Load custom metal kernels
-        let constants = [FunctionConstant<ushort>(index: 0, type: MTLDataType.ushort, value: ushort(size.kernelWidth)),
-                         FunctionConstant<ushort>(index: 1, type: MTLDataType.ushort, value: ushort(size.kernelHeight))]
-        pipelineCalculate = MetalShaderManager.shared.getFunction(name: "transpose_conv_calculate",
-                                                                  in: Bundle(for: ConvTranspose.self),
-                                                                  constants: constants)
-        pipelineShiftLeft = MetalShaderManager.shared.getFunction(name: "transpose_conv_shift_left",
-                                                                 in: Bundle(for: ConvTranspose.self),
-                                                                 constants: constants)
-        pipelineShiftTop = MetalShaderManager.shared.getFunction(name: "transpose_conv_shift_top",
-                                                                 in: Bundle(for: ConvTranspose.self),
-                                                                 constants: constants)
-
         prevSize = incoming[0].outputSize
         outputSize = LayerSize(h: prevSize.h * size.strideY,
                                w: prevSize.w * size.strideX,
@@ -77,11 +74,59 @@ open class ConvTranspose: NetworkLayer {
 
         createOutputs(size: outputSize, temporary: temporaryImage)
 
-        weightsBuffer = device.makeBuffer(bytes: weightsPointer?.pointer() ?? network.parameterLoader.loadWeights(for: id,
-                                                                                                       modifier: ConvTranspose.weightModifier,
-                                                                                                       size: getWeightsSize()),
-                                          length: getWeightsSize() * Constants.FloatSize,
-                                          options: [])
+        if #available(iOS 11.3.1, *) {
+            createCNNDescriptor(device: device)
+            makeConv(device: device)
+        } else {
+            // Load custom metal kernels
+            let constants = [FunctionConstant<ushort>(index: 0, type: MTLDataType.ushort, value: ushort(size.kernelWidth)),
+                             FunctionConstant<ushort>(index: 1, type: MTLDataType.ushort, value: ushort(size.kernelHeight))]
+            pipelineCalculate = MetalShaderManager.shared.getFunction(name: "transpose_conv_calculate",
+                                                                      in: Bundle(for: ConvTranspose.self),
+                                                                      constants: constants)
+            pipelineShiftLeft = MetalShaderManager.shared.getFunction(name: "transpose_conv_shift_left",
+                                                                     in: Bundle(for: ConvTranspose.self),
+                                                                     constants: constants)
+            pipelineShiftTop = MetalShaderManager.shared.getFunction(name: "transpose_conv_shift_top",
+                                                                     in: Bundle(for: ConvTranspose.self),
+                                                                     constants: constants)
+            weightsBuffer = device.makeBuffer(bytes: weightsPointer?.pointer() ??
+                                        network.parameterLoader.loadWeights(for: id,
+                                                                            modifier: ConvTranspose.weightModifier,
+                                                                            size: getWeightsSize()),
+                                              length: getWeightsSize() * Constants.FloatSize,
+                                              options: [])
+        }
+    }
+
+    @available(iOS 11.3.1, *)
+    open func createCNNDescriptor(device: MTLDevice) {
+        //TODO: Add neuron here?
+        cnnDescriptor = MPSCNNConvolutionDescriptor(kernelWidth: size.kernelWidth,
+                                                    kernelHeight: size.kernelHeight,
+                                                    inputFeatureChannels: prevSize.f,
+                                                    outputFeatureChannels: size.outputChannels,
+                                                    neuronFilter: nil)
+        cnnDescriptor.strideInPixelsX = size.strideX
+        cnnDescriptor.strideInPixelsY = size.strideY
+        cnnDescriptor.dilationRateX = size.dilationX
+        cnnDescriptor.dilationRateY = size.dilationY
+    }
+
+    @available(iOS 11.0, *)
+    open func makeConv(device: MTLDevice) {
+        guard let network = network else { return }
+        let dataSource = ConvolutionDataSource(cnnDescriptor: cnnDescriptor,
+                                               weights: UnsafeMutableRawPointer(mutating: weightsPointer?.pointer() ??
+                                                network.parameterLoader.loadWeights(for: id,
+                                                                                    modifier: ConvTranspose.weightModifier,
+                                                                                    size: getWeightsSize())),
+                                               bias: useBias ? UnsafeMutablePointer(mutating: biasPointer?.pointer() as UnsafePointer<Float>? ??
+                                                network.parameterLoader.loadWeights(for: id,
+                                                                                    modifier: ConvTranspose.biasModifier,
+                                                                                    size: size.outputChannels)) : nil)
+        conv = MPSCNNConvolutionTranspose(device: device, weights: dataSource)
+        self.dataSource = dataSource
     }
 
     open override func updatedCheckpoint(device: MTLDevice) {
@@ -89,7 +134,11 @@ open class ConvTranspose: NetworkLayer {
         let vector = weightsPointer?.pointer() ?? network.parameterLoader.loadWeights(for: id,
                                                                                       modifier: ConvTranspose.weightModifier,
                                                                                       size: getWeightsSize())
-        weightsBuffer.contents().copyBytes(from: vector, count: getWeightsSize() * Constants.FloatSize)
+        if #available(iOS 11.3.1, *) {
+            makeConv(device: device)
+        } else {
+            weightsBuffer.contents().copyMemory(from: vector, byteCount: getWeightsSize() * Constants.FloatSize)
+        }
     }
 
     open func getWeightsSize() -> Int {
@@ -103,59 +152,61 @@ open class ConvTranspose: NetworkLayer {
         let input = incoming[0].getOutput(index: index)
         let output = getOrCreateOutput(commandBuffer: commandBuffer, index: index)
 
-        let w = pipelineCalculate.threadExecutionWidth
-        let d = 1
-        assert(pipelineCalculate.maxTotalThreadsPerThreadgroup / w / d >= 1, "ERROR: wrong thread group size")
-        let h = pipelineCalculate.maxTotalThreadsPerThreadgroup / w / d
+        if #available(iOS 11.3.1, *), let conv = conv as? MPSCNNConvolutionTranspose {
+            conv.encode(commandBuffer: commandBuffer, sourceImage: input, destinationImage: output)
+        } else {
+            let w = pipelineCalculate.threadExecutionWidth
+            let d = 1
+            assert(pipelineCalculate.maxTotalThreadsPerThreadgroup / w / d >= 1, "ERROR: wrong thread group size")
+            let h = pipelineCalculate.maxTotalThreadsPerThreadgroup / w / d
 
-        let step1ImageSize = LayerSize(h: outputSize.h + prevSize.h, w: outputSize.w + prevSize.w, f: outputSize.f)
-        let step2ImageSize = LayerSize(h: outputSize.h + prevSize.h, w: outputSize.w, f: outputSize.f)
+            let step1ImageSize = LayerSize(h: outputSize.h + prevSize.h, w: outputSize.w + prevSize.w, f: outputSize.f)
+            let step2ImageSize = LayerSize(h: outputSize.h + prevSize.h, w: outputSize.w, f: outputSize.f)
 
-        let threadsPerGroups = MTLSizeMake(w, h, d)
-        let threadgroupsPerGrid = MTLSize(width: (input.texture.width + w - 1) / w,
-                                          height: (input.texture.height + h - 1) / h,
-                                          depth: (output.texture.arrayLength + d - 1) / d)
+            let threadsPerGroups = MTLSizeMake(w, h, d)
+            let threadgroupsPerGrid = input.texture.threadGrid(threadGroup: threadsPerGroups)
 
-        let step1Img = MPSTemporaryImage(commandBuffer: commandBuffer, imageDescriptor: MPSImageDescriptor(layerSize: step1ImageSize))
+            let step1Img = MPSTemporaryImage(commandBuffer: commandBuffer, imageDescriptor: MPSImageDescriptor(layerSize: step1ImageSize))
 
-        // calculation step
-        let encoder = commandBuffer.makeComputeCommandEncoder()!
-        encoder.label = "convT compute encoder"
-        encoder.setComputePipelineState(pipelineCalculate)
-        encoder.setTexture(input.texture, index: 0)
-        encoder.setTexture(step1Img.texture, index: 1)
-        encoder.setBuffer(weightsBuffer, offset: 0, index: 0)
+            // calculation step
+            let encoder = commandBuffer.makeComputeCommandEncoder()!
+            encoder.label = "convT compute encoder"
+            encoder.setComputePipelineState(pipelineCalculate)
+            encoder.setTexture(input.texture, index: 0)
+            encoder.setTexture(step1Img.texture, index: 1)
+            encoder.setBuffer(weightsBuffer, offset: 0, index: 0)
 
-        encoder.dispatchThreadgroups(threadgroupsPerGrid, threadsPerThreadgroup: threadsPerGroups)
-        encoder.endEncoding()
+            encoder.dispatchThreadgroups(threadgroupsPerGrid, threadsPerThreadgroup: threadsPerGroups)
+            encoder.endEncoding()
 
-        input.setRead()
+            input.setRead()
 
-        let step2Img = MPSTemporaryImage(commandBuffer: commandBuffer, imageDescriptor: MPSImageDescriptor(layerSize: step2ImageSize))
+            let step2Img = MPSTemporaryImage(commandBuffer: commandBuffer, imageDescriptor: MPSImageDescriptor(layerSize: step2ImageSize))
 
-        // shift left step
-        let encoder2 = commandBuffer.makeComputeCommandEncoder()!
-        encoder2.label = "convT shift left encoder"
-        encoder2.setComputePipelineState(pipelineShiftLeft)
-        encoder2.setTexture(step1Img.texture, index: 0)
-        encoder2.setTexture(step2Img.texture, index: 1)
+            // shift left step
+            let encoder2 = commandBuffer.makeComputeCommandEncoder()!
+            encoder2.label = "convT shift left encoder"
+            encoder2.setComputePipelineState(pipelineShiftLeft)
+            encoder2.setTexture(step1Img.texture, index: 0)
+            encoder2.setTexture(step2Img.texture, index: 1)
 
-        encoder2.dispatchThreadgroups(threadgroupsPerGrid, threadsPerThreadgroup: threadsPerGroups)
-        encoder2.endEncoding()
+            encoder2.dispatchThreadgroups(threadgroupsPerGrid, threadsPerThreadgroup: threadsPerGroups)
+            encoder2.endEncoding()
 
-        step1Img.readCount = 0
+            step1Img.readCount = 0
 
-        // shift top step
-        let encoder3 = commandBuffer.makeComputeCommandEncoder()!
-        encoder3.label = "convT shift top encoder"
-        encoder3.setComputePipelineState(pipelineShiftTop)
-        encoder3.setTexture(step2Img.texture, index: 0)
-        encoder3.setTexture(output.texture, index: 1)
+            // shift top step
+            let encoder3 = commandBuffer.makeComputeCommandEncoder()!
+            encoder3.label = "convT shift top encoder"
+            encoder3.setComputePipelineState(pipelineShiftTop)
+            encoder3.setTexture(step2Img.texture, index: 0)
+            encoder3.setTexture(output.texture, index: 1)
 
-        encoder3.dispatchThreadgroups(threadgroupsPerGrid, threadsPerThreadgroup: threadsPerGroups)
-        encoder3.endEncoding()
+            encoder3.dispatchThreadgroups(threadgroupsPerGrid, threadsPerThreadgroup: threadsPerGroups)
+            encoder3.endEncoding()
 
-        step2Img.readCount = 0
+            step2Img.readCount = 0
+        }
     }
 
 }

--- a/Sources/Layers/ConvTranspose.swift
+++ b/Sources/Layers/ConvTranspose.swift
@@ -113,7 +113,7 @@ open class ConvTranspose: NetworkLayer {
         cnnDescriptor.dilationRateY = size.dilationY
     }
 
-    @available(iOS 11.0, *)
+    @available(iOS 11.3.1, *)
     open func makeConv(device: MTLDevice) {
         guard let network = network else { return }
         let dataSource = ConvolutionDataSource(cnnDescriptor: cnnDescriptor,


### PR DESCRIPTION
There seems to be an issue in iOS 11.3.1 which makes several of our shaders break. This is a workaround for that

