### PR TITLE
Release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Change Log
 All notable changes to Bender will be documented in this file.
 
+## [0.5.0](https://github.com/xmartlabs/Bender/releases/tag/0.5.0)
+
+Added:
+
+* BatchNorm
+* Support for multiple inputs
+* Add support for depthwise and atrous (dilated) convolutions in iOS 11
+* Change some kernels to run on half instead of float
+* Use MPSTemporaryImage by default
+
+and some fixes.
+
 ## [0.4.1](https://github.com/xmartlabs/Bender/releases/tag/0.4.1)
 
 * Support for Xcode 9.1.

--- a/MetalBender.podspec
+++ b/MetalBender.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "MetalBender"
-  s.version          = "0.4.1"
+  s.version          = "0.5.0"
   s.summary          = "Bender is an abstraction layer over MetalPerformanceShaders useful for working with neural networks."
   s.homepage         = "https://github.com/xmartlabs/Bender"
   s.license          = { type: 'MIT', file: 'LICENSE' }

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Follow these steps to run the examples:
 * Open Bender workspace and run the *Example* project.
 
 > There is an Image recognition example which includes a MobileNet model in Bender and one in CoreML. It is also set up to run an Inception model but you will have to download it separately as it is almost 100 MB in size.
-You can download it from http://download.tensorflow.org/models/inception_v3_2016_08_28.tar.gz but then you have to freeze it and add it to the 'Example' Xcode project as 'inception_v3.pb'. 
+You can download it from http://download.tensorflow.org/models/inception_v3_2016_08_28.tar.gz but then you have to freeze it and add it to the 'Example' Xcode project as 'inception_v3.pb'.
 
 ## Installation
 
@@ -118,7 +118,7 @@ You can download it from http://download.tensorflow.org/models/inception_v3_2016
 To install Bender, simply add the following line to your Podfile:
 
 ```ruby
-pod 'MetalBender', '~> 0.4'
+pod 'MetalBender', '~> 0.5'
 ```
 
 > Remember that Bender compiles for iOS 10. So you must add `platform :ios, '10.0'` to your Podfile
@@ -130,7 +130,7 @@ pod 'MetalBender', '~> 0.4'
 To install Bender, add the following line to your Cartfile:
 
 ```ogdl
-github "xmartlabs/Bender" ~> 0.4
+github "xmartlabs/Bender" ~> 0.5
 ```
 
 Then run:


### PR DESCRIPTION
Added:

* BatchNorm
* Support for multiple inputs
* Add support for depthwise and atrous (dilated) convolutions in iOS 11
* Change some kernels to run on half instead of float
* Use MPSTemporaryImage by default

and some fixes.
